### PR TITLE
Self xrefs now working.

### DIFF
--- a/src/vfb_query_builder/test/TermInfo_schema_tests.py
+++ b/src/vfb_query_builder/test/TermInfo_schema_tests.py
@@ -36,7 +36,7 @@ class TermInfoRollerTest(unittest.TestCase):
         query = query_builder(query_labels=["Class"],
                               clauses=[self.ql.term(), 
                                        self.ql.xrefs()],
-                              query_short_forms=['FBbt_00007422'])
+                              query_short_forms=['FBti0143498'])
         r = self.qw.test(t=self,
                          query=query)
 


### PR DESCRIPTION
Needs to be tested against rebuild pdb(-dev) minus Robbie's xref expansion for FlyBase - there are some changes  in KB that need to filter through.  Note - only  added for features to date - not for ontology terms as I think these should be dealt with separately (adding xrefs to various external ontology browsers).