### PR TITLE
Cypher query roller refactoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jsonschema
 requests
 vfb_connect
+python_cypher

--- a/src/vfb_query_builder/pypher_query_roller.py
+++ b/src/vfb_query_builder/pypher_query_roller.py
@@ -1,0 +1,309 @@
+from dataclasses import dataclass, field
+from typing import List
+from pypher import Pypher, Param, __, create_function, create_statement
+import subprocess
+
+
+empty_str = Param('empty_str', "''")
+first_index = Param('first_index', 0)
+create_function('labels', {'name': 'labels'})
+create_statement('CALL', {'name': 'CALL'})
+create_statement('YIELD', {'name': 'YIELD'})
+
+
+def get_version_tag():
+    tag = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
+    return tag.decode(encoding='ascii').rstrip()
+
+
+@dataclass
+class Clause:
+    MATCH: Pypher
+    WITH: Pypher
+    vars: List[str] = field(default_factory=list)
+    RETURN: Pypher = None
+    node_vars: List[str] = field(default_factory=list)
+    starting_short_forms: list = field(default_factory=list)
+    starting_labels: list = field(default_factory=list)
+    match_params: dict = field(default_factory=dict)
+    with_params: dict = field(default_factory=dict)
+    pvar: str = 'primary'
+    limit: str = ''
+    prel: str = ''
+
+    def get_match(self, varz):
+        """Generate a cypher string using the attributes of this clause object,
+        interpolating a list of variables specified by the varz arg"""
+        clause_params = dict()
+        clause_params["pvar"] = self.pvar
+        clause_params["v"] = ', '.join(varz)
+        clause_params["ssf"] = str(self.starting_short_forms)
+        clause_params["labels"] = ':'.join(self.starting_labels)
+        clause_params["prel"] = self.prel
+        clause_params["limit"] = self.limit
+
+        params = {**self.match_params, **clause_params}
+        return __().raw(inplace_bound_params(str(self.MATCH), params))
+
+    def get_with(self, varz):
+        if varz:
+            self.WITH.append(__().raw(',' + ','.join(varz)))
+        return __().raw(inplace_bound_params(str(self.WITH), self.with_params))
+
+
+def query_builder(clauses: List[Clause], query_short_forms=None,
+                  query_labels=None, pretty_print=True, annotate=True, q_name=''):
+    """clauses: A list of Clause objects. The first element in the list must be an initial clause.
+    Initial clauses must have slot for short_forms """
+    if query_labels is None:
+        query_labels = []
+    clauses[0].starting_short_forms = query_short_forms
+    clauses[0].starting_labels = query_labels
+
+    # Stacks
+    node_vars = []
+    data_vars = []
+    return_clauses = [__.RETURN]
+
+    q = Pypher()
+    for c in clauses:
+        q.append(c.get_match(varz=node_vars + data_vars))
+        q.WITH.append(c.get_with(varz=node_vars + data_vars))
+        node_vars.extend(c.node_vars)
+        data_vars.extend(c.vars)
+        if c.RETURN:
+            return_clauses.append(c.RETURN)
+
+    if annotate:
+        if q_name:
+            return_clauses.append(__().raw(q_name).AS(__.query))
+        return_clauses.append(__().raw("'" + str(get_version_tag()) + "'").AS(__.version))
+    return_clauses.append(__().raw(','.join(data_vars)))
+
+    return_clause_count = 0
+    for return_clause in return_clauses:
+        q.append(return_clause)
+        if 0 < return_clause_count < len(return_clauses)-1:
+            q.append(__().raw(","))
+        return_clause_count += 1
+
+    return inplace_bound_params(str(q), q.bound_params)
+
+
+class QueryLibraryCore:
+
+    def __init__(self):
+        # Using methods for ease of reading code - so these can be next to queries where they apply.
+        self._set_image_query_common_elements()
+        self._set_pub_common_query_elements()
+
+    def term(self):
+        return Clause(
+            MATCH=__.MATCH.node('primary', labels='$labels')
+                    .WHERE.primary.property('short_form').operator('in', Param('ssf', str(''))),
+            WITH=__.primary,
+            node_vars=['primary'],
+            RETURN=roll_node_map(
+                typ='extended_core',
+                var='primary').append(__.alias(__.term))
+        )
+
+    # EXPRESSION QUERIES
+
+    def xrefs(self):
+        match_self_xref = __.OptionalMatch.node("s", "Site", short_form=
+                            __().func("apoc.convert.toList", __.primary.property("self_xref"))[first_index])
+        match_ext_xref = __.OptionalMatch.node("s", "Site").rel_in("dbx", "database_cross_reference").node("$pvar", "$labels")
+
+        xr = __.CASE.WHEN.s.IS_NULL.THEN(Param("param1", "param1")).ELSE.COLLECT(__.map(
+            link_base=__.coalesce(__.s.property('link_base')[first_index], empty_str),
+            accession=__.coalesce(Param("accession_param", "accession_param"), empty_str),
+            link_text=__.primary.property("label") + __().raw("' on '") + __.s.property("label"),
+            homepage=__.coalesce(__.s.property('homepage')[first_index], empty_str),
+            site=__().bind_param("site_param", "site_param"),
+            icon=__.coalesce(__.s.property('link_icon_url')[first_index], empty_str),
+            link_postfix=__.coalesce(__.s.property("link_postfix"), empty_str)
+            ))  # Should be $pvar$labels not primary, but need sub on WITH!
+        xrs = __.END.AS(__.self_xref).raw(", $v")  # Passing vars
+        xrx = __().raw("+").self_xref.END.AS(__.xrefs)
+
+        return Clause(
+            MATCH=match_self_xref.append(__.WITH).append(xr.clone()).append(xrs).append(match_ext_xref),
+            WITH=xr.clone().append(xrx),
+            vars=["xrefs"],
+            match_params={"param1": "[]",
+                         "accession_param": "primary.short_form",
+                         "site_param": roll_min_node_info("s"),
+                         },
+            with_params={"param1": "self_xref",
+                         "accession_param": "dbx.accession[0]",
+                         "site_param": roll_min_node_info("s"),
+                         }
+            )
+
+    # RELATIONSHIPS
+
+    def parents(self): return Clause(vars=["parents"],
+                                     MATCH=__.OptionalMatch.node("o", "Class").rel_in("r", "SUBCLASSOF|INSTANCEOF")
+                                     .node("$pvar", "$labels"),
+                                     WITH=__.CASE.WHEN.o.IS_NULL.THEN([])
+                                     .ELSE.COLLECT(__().raw(roll_min_node_info("o"))).END.AS("parents")
+                                     )  # Draft
+
+    def relationships(self): return (Clause(vars=["relationships"],
+                                            MATCH=__.OptionalMatch.node("o", "Class")
+                                            .rel_in("r", "", type=__().raw("'Related'")).node("$pvar", "$labels"),
+                                            WITH=__.CASE.WHEN.o.IS_NULL.THEN([])
+                                                .ELSE.COLLECT(__.map(
+                                                    relation=Param("info_r_param", "info_r_param"),
+                                                    object=Param("info_o_param", "info_o_param")
+                                                )).END.AS(__().raw("relationships")),
+                                            with_params={"info_r_param": roll_min_edge_info("r"),
+                                                         "info_o_param": roll_min_node_info("o")
+                                                         }
+                                            ))
+
+    def test_func(self):
+        q = Pypher()
+        q + __.self_xref.END.AS(__.xrefs)
+        print(__().raw("") + __.self_xref.END.AS(__.xrefs))
+
+    def anatomy_channel_image(self):
+        return Clause(
+            MATCH=__.CALL.func("apoc.cypher.run", __().raw("'")
+                                .WITH(Param("$pvar", ""))
+                                .OptionalMatch.node("$pvar", "$labels").rel_in("", "has_source|SUBCLASSOF|INSTANCEOF*")
+                                .node("i", "Individual")
+                                .rel_in("", "depicts").node("channel", "Individual").rel_out("irw", "in_register_with")
+                                .node("template", "Individual").rel_out("", "depicts").node("template_anat", "Individual")
+                                .RETURN(__.template, __.channel, __.template_anat, __.i, __.irw)
+                                .Limit(5)
+                                .raw("'"), __.map("$pvar:$pvar"))
+            .YIELD(__.value.WITH.value.property("template").AS(__.template), __.value.property("channel").AS(__.channel),
+                   __.value.property("template_anat").AS(__.template_anat), __.value.property("i").AS(__.i),
+                   __.value.property("irw").AS(__.irw), Param("$v", ""))
+            .OptionalMatch.node("channel").rel_out(labels="is_specified_output_of").node("technique", "Class"),
+            WITH=__.CASE.WHEN.channel.IS_NULL.THEN([])
+                .ELSE.COLLECT(__.map(anatomy=roll_min_node_info("i"), channel_image=self._channel_image_return))
+                .END.AS(__.anatomy_channel_image),
+            vars=["anatomy_channel_image"],
+            limit='limit 5, {}) yield value'
+        )
+
+    def _set_image_query_common_elements(self):
+        # TODO check $v %s $limit
+        self._channel_image_match = __().rel_in(labels="depicts").node("channel", "Individual").rel_out("irw", "in_register_with")\
+            .node("template", "Individual").rel_out(labels="depicts").node("template_anat", "Individual")\
+            .WITH(__.template, __.channel, __.template_anat, __.irw, __().raw("$v $param1 $limit"))\
+            .OptionalMatch.node("channel").rel_out(labels="is_specified_output_of").node("technique", "Class")
+        self._channel_image_return = __.map(
+            channel=roll_min_node_info('channel'),
+            imaging_technique=roll_min_node_info('technique'),
+            image=__.map(
+                template_channel=roll_min_node_info('template'),
+                template_anatomy=roll_min_node_info('template_anat'),
+                image_folder=__.coalesce(__.irw.property('folder')[first_index], empty_str),
+                index=__.coalesce(__().func("apoc.convert.toInteger", __.irw.property('index')[first_index]),
+                                  __.List()) + __.List()
+            )
+        )
+
+    def channel_image(self):
+        return Clause(
+            MATCH=__.OptionalMatch.node("$pvar", "$labels").append(self._channel_image_match.clone()),
+            WITH=__.CASE.WHEN.channel.IS_NULL.THEN([])
+                    .ELSE.COLLECT(self._channel_image_return.clone()).END.AS(__.channel_image),
+            match_params={"param1": ""},
+            vars=["channel_image"])
+
+    ## PUBS
+
+    def _set_pub_common_query_elements(self):
+        # This is only a function for ease of code editing - places declaration next to where it is used.
+        self._pub_return = __.map(
+            core=roll_min_node_info("p"),
+            PubMed=__.coalesce(__.p.property('PMID')[first_index], empty_str),
+            FlyBase=__.coalesce(__.p.property('FlyBase')[first_index], empty_str),
+            DOI=__.coalesce(__.p.property('DOI')[first_index], empty_str)
+        )
+
+        # temp fixes in here for list -> single !
+        self._syn_return = __.map(
+            label=__.coalesce(__.rp.property('value')[first_index], empty_str),
+            scope=__.coalesce(__.rp.property('scope')[first_index], empty_str),
+            type=__.coalesce(__.rp.property('has_synonym_type')[first_index], empty_str),
+        )
+
+    def def_pubs(self):
+        return Clause(
+            MATCH=__.OptionalMatch.node("$pvar", "$labels").rel_out("rp", "has_reference").node("p", "pub")
+                    .WHERE.rp.property("typ") == __().raw("'def'"),
+            WITH=__.CASE.WHEN.p.IS_NULL.THEN([])
+                    .ELSE.COLLECT(__().raw(self._pub_return)).END.AS(__.def_pubs),
+            vars=['def_pubs'])
+
+    def pub_syn(self):
+        return Clause(
+            MATCH=__.OptionalMatch.node("$pvar", "$labels").rel_out("rp", "has_reference").node("p", "pub")
+                    .WHERE.rp.property("typ") == __().raw("'syn'"),  # tmp fix rp.typ shld be []]!
+            WITH=__.CASE.WHEN.p.IS_NULL.THEN([])
+                    .ELSE.COLLECT(__.map(
+                            pub=self._pub_return,
+                            synonym=self._syn_return
+                    )).END.AS(__.pub_syn),
+            vars=['pub_syn'])
+
+
+class QueryLibrary(QueryLibraryCore):
+    pass
+
+
+def inplace_bound_params(cypher, params):
+    """
+    Embeds bound query param values in the query string.
+
+    Return: updated query string
+    """
+    for param in params:
+        cypher = cypher.replace("$" + param, str(params[param]))
+    return cypher
+
+
+def roll_min_node_info(var):
+    """Rolls core JSON (specifying minimal info about an entity.
+    var: the variable name for the entity within this cypher clause."""
+    return __.map(
+                    short_form=__().raw(var).property('short_form'),
+                    label=__.coalesce(__().raw(var).property('label'), empty_str),
+                    iri=__().raw(var).property('iri'),
+                    types=__.labels(__().raw(var)),
+                    symbol=__.coalesce(__().raw(var).property('symbol')[first_index], empty_str)
+                )
+
+
+def roll_min_edge_info(var):
+    """Rolls core JSON (specifying minimal info about an edge.
+    var: the variable name for the edge within this cypher clause."""
+    return __.map(
+        label=__().raw(var).property('label'),
+        iri=__().raw(var).property('iri'),
+        type=__().type(__().raw(var))
+    )
+
+
+def roll_node_map(var: str, typ=''):
+    node_map = None
+    if typ:
+        if typ == 'core':
+            node_map = __.map(
+                core=roll_min_node_info(var)
+            )
+        elif typ == 'extended_core':
+            node_map = __.map(
+                core=roll_min_node_info(var),
+                description=__.coalesce(__.primary.property('description'), __.List()),
+                comment=__.coalesce(__.primary.property('comment'), __.List()),
+            )
+        else:
+            raise Exception('Unknown type: %s should be one or core, extended_core' % typ)
+    return node_map

--- a/src/vfb_query_builder/pypher_query_roller.py
+++ b/src/vfb_query_builder/pypher_query_roller.py
@@ -370,8 +370,8 @@ class QueryLibraryCore:
         return Clause(
             MATCH=__.OptionalMatch.node("$pvar").rel_in(labels="has_source").node("i", "Individual")
                 .WITH(__.i, __().raw("$v")).OptionalMatch.node("i").rel(labels="INSTANCEOF").node("c", "Class"),
-            WITH=__.Distinct(__.map(images=__.count(__.Distinct(__.i)),
-                                 types=__.count(__.Distinct(__.c)))).AS(__.dataset_counts),
+            WITH=__().raw("DISTINCT").map(images=__.count(__.Distinct(__.i)),
+                                 types=__.count(__.Distinct(__.c))).AS(__.dataset_counts),
             vars=['dataset_counts']
         )
 
@@ -604,10 +604,10 @@ class QueryLibrary(QueryLibraryCore):
 
     def template_2_datasets_wrapper(self):
         return Clause(MATCH=__.MATCH.node("t", "Template").rel_in("depicts").node("tc", "Template")
-                          .rel(labels="in_register_with").node("c", "Individual").rel_out("depicts")
+                          .rel(labels="in_register_with").node("c", "Individual").rel_out(labels="depicts")
                           .node("ai", "Individual").rel_out(labels="has_source").node("ds", "DataSet")
                           .WHERE.t.property("short_form").operator('in', Param('ssf', "ssf")),
-                      WITH=__.Distinct(__.ds),
+                      WITH=__().raw("DISTINCT").ds,
                       vars=[],
                       node_vars=['ds'],
                       RETURN=__().append(roll_min_node_info('ds').clone()).AS("dataset")

--- a/src/vfb_query_builder/test/TermInfo_pypher_schema_test.py
+++ b/src/vfb_query_builder/test/TermInfo_pypher_schema_test.py
@@ -103,5 +103,19 @@ class TermInfoRollerTest(unittest.TestCase):
         r = self.qw.test(t=self,
                          query=query)
 
+    def test_individual_dataset_license(self):
+        query = query_builder(query_labels=["Individual"],
+                              clauses=[self.ql.term(),
+                                       self.ql.dataSet_license()],
+                              query_short_forms=['VFB_00011179'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_class(self):
+        query = self.ql.class_term_info(short_form=['FBbt_00047035'])
+        r = self.qw.test(t=self,
+                         query=query)
+
     def test_convert(self):
         self.ql.test_func()
+

--- a/src/vfb_query_builder/test/TermInfo_pypher_schema_test.py
+++ b/src/vfb_query_builder/test/TermInfo_pypher_schema_test.py
@@ -116,6 +116,99 @@ class TermInfoRollerTest(unittest.TestCase):
         r = self.qw.test(t=self,
                          query=query)
 
-    def test_convert(self):
-        self.ql.test_func()
+    def test_individual(self):
+        query = self.ql.anatomical_ind_term_info(short_form=['VFB_jrchjtdq'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_dataset_license(self):
+        query = query_builder(query_labels=['DataSet'],
+                              query_short_forms=['Ito2013'],
+                              clauses=[self.ql.term(),
+                                       self.ql.license()])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_dataset(self):
+        query = self.ql.dataset_term_info(short_form=['Ito2013'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_license(self):
+        query = self.ql.license_term_info(short_form=['VFBlicense_CC_BY_SA_4_0'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_dataset_xrefs(self):
+        query = query_builder(query_labels=['DataSet'],
+                              query_short_forms=['Ito2013'],
+                              clauses=[self.ql.term(),
+                                       self.ql.xrefs()])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_dataset_pub(self):
+        query = query_builder(query_labels=['DataSet'],
+                              query_short_forms=['Ito2013'],
+                              clauses=[self.ql.term(),
+                                       self.ql.pubs()])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_dataset_anatomy_channel_image(self):
+        query = query_builder(query_labels=['DataSet'],
+                              query_short_forms=['Ito2013'],
+                              clauses=[self.ql.term(),
+                                       self.ql.anatomy_channel_image()])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_template(self):
+        query = self.ql.template_term_info(short_form=["VFB_00017894"], pretty_print=True)
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_template_domains(self):
+        query = query_builder(query_labels=['Template'],
+                              query_short_forms=['VFB_00017894'],
+                              clauses=[self.ql.term(),
+                                       self.ql.template_domain()])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_template_channel(self):
+        query = query_builder(query_labels=['Template'],
+                              query_short_forms=['VFB_00017894'],
+                              clauses=[self.ql.term(),
+                                       self.ql.template_channel()])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_neuron_class(self):
+        query = self.ql.neuron_class_term_info(short_form=["FBbt_00047609"], pretty_print=True)
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_neuron_class_null_split(self):
+        # Splits unlikely to be directly annotated with neuron only
+        query = self.ql.neuron_class_term_info(short_form=["FBbt_00005106"], pretty_print=True)
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_split_class(self):
+        query = self.ql.split_class_term_info(short_form=["VFBexp_FBtp0123136FBtp0119953"], pretty_print=True)
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_pub(self):
+        query = self.ql.pub_term_info(short_form=['FBrf0221438'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def tearDown(self):
+        return
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)
 

--- a/src/vfb_query_builder/test/TermInfo_pypher_schema_test.py
+++ b/src/vfb_query_builder/test/TermInfo_pypher_schema_test.py
@@ -1,0 +1,107 @@
+import unittest
+from vfb_query_builder.pypher_query_roller import QueryLibrary, query_builder
+from .test_tools import TestWrapper
+
+
+class TermInfoRollerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.ql = QueryLibrary()
+        self.qw = TestWrapper('vfb_termInfo.json')
+        print("Running", self.id().split('.')[1:])
+
+    def test_class_term(self):
+        query = query_builder(query_labels=["Class"],
+                              clauses=[self.ql.term()],
+                              query_short_forms=['FBbt_00000591'])
+
+        r = self.qw.test(t=self, query=query)
+
+    def test_individual_term(self):
+        query = query_builder(query_labels=["Individual"],
+                              clauses=[self.ql.term()],
+                              query_short_forms=['VFB_00011179'])
+        r = self.qw.test(t=self, query=query)
+
+    def test_class_images(self):
+        query = query_builder(query_labels=["Class"],
+                              clauses=[self.ql.term(),
+                                       self.ql.anatomy_channel_image()],
+                              query_short_forms=['FBbt_00007422'])
+        print(query)
+        r = self.qw.test(t=self, query=query)
+
+    def test_class_xrefs(self):
+        query = query_builder(query_labels=["Class"],
+                              clauses=[self.ql.term(),
+                                       self.ql.xrefs()],
+                              query_short_forms=['VFBexp_FBtp0123937FBtp0120068'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_class_parents(self):
+        query = query_builder(query_labels=["Class"],
+                              clauses=[self.ql.term(),
+                                       self.ql.parents()],
+                              query_short_forms=['FBbt_00007422'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_class_relationships(self):
+        query = query_builder(query_labels=["Class"],
+                              clauses=[self.ql.term(),
+                                       self.ql.relationships()],
+                              query_short_forms=['FBbt_00007422'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_class_def_pubs(self):
+        query = query_builder(query_labels=["Class"],
+                              clauses=[self.ql.term(),
+                                       self.ql.def_pubs()],
+                              query_short_forms=['FBbt_00000591'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_class_pub_syn(self):
+        query = query_builder(query_labels=["Class"],
+                              clauses=[self.ql.term(),
+                                       self.ql.pub_syn()],
+                              query_short_forms=['FBbt_00000591'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_individual_relationships(self):
+        query = query_builder(query_labels=["Individual"],
+                              clauses=[self.ql.term(),
+                                       self.ql.relationships()],
+                              query_short_forms=['VFB_00011179'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_individual_parents(self):
+        query = query_builder(query_labels=["Individual"],
+                              clauses=[self.ql.term(),
+                                       self.ql.parents()],
+                              query_short_forms=['VFB_00011179'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_individual_xrefs(self):
+        query = query_builder(query_labels=["Individual"],
+                              clauses=[self.ql.term(),
+                                       self.ql.xrefs()],
+                              query_short_forms=['VFB_00010249'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_individual_image(self):
+        query = query_builder(query_labels=["Individual"],
+                              clauses=[self.ql.term(),
+                                       self.ql.channel_image()],
+                              query_short_forms=['VFB_00011179'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+    def test_convert(self):
+        self.ql.test_func()

--- a/src/vfb_query_builder/test/pypher/TermInfo_pypher_schema_test.py
+++ b/src/vfb_query_builder/test/pypher/TermInfo_pypher_schema_test.py
@@ -1,6 +1,6 @@
 import unittest
 from vfb_query_builder.pypher_query_roller import QueryLibrary, query_builder
-from .test_tools import TestWrapper
+from vfb_query_builder.test.test_tools import TestWrapper
 
 
 class TermInfoRollerTest(unittest.TestCase):

--- a/src/vfb_query_builder/test/pypher/results_schema_tests.py
+++ b/src/vfb_query_builder/test/pypher/results_schema_tests.py
@@ -1,0 +1,58 @@
+import unittest
+from vfb_query_builder.pypher_query_roller import QueryLibrary, query_builder
+from vfb_query_builder.test.test_tools import TestWrapper
+
+
+class QueryRollerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.ql = QueryLibrary()
+        self.qw = TestWrapper('vfb_query.json')
+
+        print("Running", self.id().split('.')[1:])
+
+    def test_anat_2_ep_query(self):
+        query = self.ql.anat_2_ep_query(short_forms=["FBbt_00050101", "FBbt_00050253", "FBbt_00050143", "FBbt_00050167", "FBbt_00110412", "FBbt_00100218", "FBbt_00003638", "FBbt_00003662", "FBbt_00003641", "FBbt_00003639", "FBbt_00110325", "FBbt_00111506", "FBbt_00111052", "FBbt_00111507", "FBbt_00111508", "FBbt_00111053", "FBbt_00111509", "FBbt_00111510", "FBbt_00111055", "FBbt_00111054", "FBbt_00040033", "FBbt_00110151", "FBbt_00003646", "FBbt_00003643", "FBbt_00110326", "FBbt_00007566", "FBbt_00007565", "FBbt_00007564", "FBbt_00007563", "FBbt_00007562", "FBbt_00007561", "FBbt_00007560", "FBbt_00007559", "FBbt_00003634"], pretty_print=True)
+
+        print("Testing and printing first result in list only.")
+        r = self.qw.test(t=self,
+                         query=query, single=False)
+
+    def test_anat_image_query(self):
+        query=self.ql.anat_image_query(short_forms=["VFB_00002007", "VFB_00002009", "VFB_00002016", "VFB_00002014", "VFB_00012703", "VFB_00002587", "VFB_00002583", "VFB_00002582", "VFB_00013568", "VFB_00013655", "VFB_00003307", "VFB_00013598", "VFB_00003302", "VFB_00003301", "VFB_00003342", "VFB_00009590", "VFB_00013448", "VFB_00008176", "VFB_00013523", "VFB_00001720", "VFB_00003369", "VFB_00003268", "VFB_00003361", "VFB_00003281", "VFB_00013613", "VFB_00013779", "VFB_00013510", "VFB_00013456", "VFB_00013534", "VFB_00013751", "VFB_00013390", "VFB_00003255", "VFB_00003277", "VFB_00013529", "VFB_00003073", "VFB_00013481", "VFB_00013544", "VFB_00013742", "VFB_00013341", "VFB_00013385", "VFB_00013462", "VFB_00013581", "VFB_00003104", "VFB_00013536", "VFB_00013339", "VFB_00003180", "VFB_00013736", "VFB_00013616", "VFB_00013556", "VFB_00010481", "VFB_00013513", "VFB_00013711", "VFB_00013594", "VFB_00013474", "VFB_00010486", "VFB_00013552", "VFB_00013750", "VFB_00013592", "VFB_00010480", "VFB_00003313", "VFB_00003357", "VFB_00003231", "VFB_00003275", "VFB_00013702", "VFB_00003192", "VFB_00013765", "VFB_00010491", "VFB_00003326", "VFB_00003124", "VFB_00003246", "VFB_00003123", "VFB_00003165", "VFB_00013717", "VFB_00013437", "VFB_00013535", "VFB_00013574", "VFB_00013651", "VFB_00013498", "VFB_00003211", "VFB_00003296", "VFB_00003250", "VFB_00013729", "VFB_00013767", "VFB_00013406", "VFB_00100736", "VFB_00100737", "VFB_00100742", "VFB_00100741", "VFB_00003308", "VFB_00003309", "VFB_00003311", "VFB_00003319", "VFB_00003338", "VFB_00003335", "VFB_00003347", "VFB_00003364", "VFB_00003365", "VFB_00003363", "VFB_00003413", "VFB_00003126", "VFB_00003168", "VFB_00003166", "VFB_00003171", "VFB_00003184", "VFB_00003181", "VFB_00003208", "VFB_00003218", "VFB_00003239", "VFB_00003252", "VFB_00003264", "VFB_00003261", "VFB_00003262", "VFB_00003260", "VFB_00003278", "VFB_00003293", "VFB_00013466", "VFB_00013403", "VFB_00013562", "VFB_00013662", "VFB_00013580", "VFB_00013459", "VFB_00013697", "VFB_00003077", "VFB_00013400", "VFB_00013434", "VFB_00013500", "VFB_00013512", "VFB_00013557", "VFB_00013520", "VFB_00013630", "VFB_00003087", "VFB_00013615", "VFB_00013533", "VFB_00010471", "VFB_00003046", "VFB_00000946", "VFB_00013508", "VFB_00011250", "VFB_00013775", "VFB_00010469", "VFB_00013472", "VFB_00013719", "VFB_00013343", "VFB_00013596", "VFB_00013564", "VFB_00013982", "VFB_00003534", "VFB_00011227", "VFB_00013503", "VFB_00013515", "VFB_00013438", "VFB_00010475", "VFB_00003086", "VFB_00010479", "VFB_00013422", "VFB_00013522", "VFB_00013524", "VFB_00010477", "VFB_00013463", "VFB_00013563", "VFB_00013585", "VFB_00000590", "VFB_00013334", "VFB_00013477", "VFB_00013412", "VFB_00013495", "VFB_00013397", "VFB_00013496", "VFB_00013573", "VFB_00013493", "VFB_00013727", "VFB_00013728", "VFB_00013547", "VFB_00013726", "VFB_jrch0a7d", "VFB_jrch0a7c", "VFB_jrch0a2r", "VFB_jrch0a2p", "VFB_jrch0a3d", "VFB_jrch0a8x", "VFB_jrch0b0e", "VFB_jrch0b8f", "VFB_jrch0b9k", "VFB_jrch0b2d", "VFB_jrch0agt", "VFB_jrch0ahm", "VFB_jrch0aj7", "VFB_jrch0aib", "VFB_jrch0aej", "VFB_jrch0as3", "VFB_jrch0ajc", "VFB_jrch0akw", "VFB_jrch0an1", "VFB_jrch0c8z", "VFB_jrch0awo", "VFB_jrch0c5d", "VFB_jrch0av6", "VFB_jrch0atl", "VFB_00102735", "VFB_00102716"])
+        print("Testing and printing first result in list only.")
+        r = self.qw.test(t=self,
+                         query=query, single=False)
+
+    ## Disabled queries take too much time and don't return result
+
+    # def test_ep_2_anat_query(self):
+    #     query = self.ql.ep_2_anat_query('VFBexp_FBtp0106753',
+    #                                    pretty_print=True,)
+    #
+    #     print("Testing and printing first result in list only.")
+    #     r = self.qw.test(t=self,
+    #                      query=query, single=False)
+    #
+    # def test_template_2_datasets_query(self):
+    #     query = self.ql.template_2_datasets_query('VFB_00050000')
+    #     print("Testing and printing first result in list only.")
+    #     r = self.qw.test(t=self,
+    #                      query=query, single=False)
+    #
+    # def test_all_datasets_query(self):
+    #     query = self.ql.all_datasets_query()
+    #     print("Testing and printing first result in list only.")
+    #     r = self.qw.test(t=self,
+    #                      query=query, single=False)
+    #
+    # def test_anatomy_query(self):
+    #     query = self.ql.anat_query(short_forms=['FBbt_00048350', 'FBbt_00047826', 'FBbt_00111338', 'FBbt_00048346', 'FBbt_00047227', 'FBbt_00007445', 'FBbt_00003864', 'FBbt_00007452', 'FBbt_00111354', 'FBbt_00007476', 'FBbt_00111661', 'FBbt_00049514', 'FBbt_00100470', 'FBbt_00100225', 'FBbt_00110570', 'FBbt_00111685', 'FBbt_00047723', 'FBbt_00110086', 'FBbt_00067349', 'FBbt_00007444', 'FBbt_00048354', 'FBbt_00003879', 'FBbt_00111481', 'FBbt_00067369', 'FBbt_00111359', 'FBbt_00067350', 'FBbt_00111749', 'FBbt_00100485', 'FBbt_00003994', 'FBbt_00007437', 'FBbt_00110427', 'FBbt_00110983', 'FBbt_00047681', 'FBbt_00067123', 'FBbt_00111715', 'FBbt_00047724', 'FBbt_00047825', 'FBbt_00047429', 'FBbt_00048353', 'FBbt_00111470', 'FBbt_00003875', 'FBbt_00067021', 'FBbt_00100381', 'FBbt_00111355', 'FBbt_00047720', 'FBbt_00067364', 'FBbt_00100388', 'FBbt_00048520', 'FBbt_00003880', 'FBbt_00100489'])
+    #     print("Testing and printing first result in list only.")
+    #     r = self.qw.test(t=self,
+    #                      query=query, single=False)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)
+

--- a/src/vfb_query_builder/test/pypher/results_schema_tests.py
+++ b/src/vfb_query_builder/test/pypher/results_schema_tests.py
@@ -24,33 +24,31 @@ class QueryRollerTest(unittest.TestCase):
         r = self.qw.test(t=self,
                          query=query, single=False)
 
-    ## Disabled queries take too much time and don't return result
+    def test_ep_2_anat_query(self):
+        query = self.ql.ep_2_anat_query('VFBexp_FBtp0106753',
+                                       pretty_print=True,)
 
-    # def test_ep_2_anat_query(self):
-    #     query = self.ql.ep_2_anat_query('VFBexp_FBtp0106753',
-    #                                    pretty_print=True,)
-    #
-    #     print("Testing and printing first result in list only.")
-    #     r = self.qw.test(t=self,
-    #                      query=query, single=False)
-    #
-    # def test_template_2_datasets_query(self):
-    #     query = self.ql.template_2_datasets_query('VFB_00050000')
-    #     print("Testing and printing first result in list only.")
-    #     r = self.qw.test(t=self,
-    #                      query=query, single=False)
-    #
-    # def test_all_datasets_query(self):
-    #     query = self.ql.all_datasets_query()
-    #     print("Testing and printing first result in list only.")
-    #     r = self.qw.test(t=self,
-    #                      query=query, single=False)
-    #
-    # def test_anatomy_query(self):
-    #     query = self.ql.anat_query(short_forms=['FBbt_00048350', 'FBbt_00047826', 'FBbt_00111338', 'FBbt_00048346', 'FBbt_00047227', 'FBbt_00007445', 'FBbt_00003864', 'FBbt_00007452', 'FBbt_00111354', 'FBbt_00007476', 'FBbt_00111661', 'FBbt_00049514', 'FBbt_00100470', 'FBbt_00100225', 'FBbt_00110570', 'FBbt_00111685', 'FBbt_00047723', 'FBbt_00110086', 'FBbt_00067349', 'FBbt_00007444', 'FBbt_00048354', 'FBbt_00003879', 'FBbt_00111481', 'FBbt_00067369', 'FBbt_00111359', 'FBbt_00067350', 'FBbt_00111749', 'FBbt_00100485', 'FBbt_00003994', 'FBbt_00007437', 'FBbt_00110427', 'FBbt_00110983', 'FBbt_00047681', 'FBbt_00067123', 'FBbt_00111715', 'FBbt_00047724', 'FBbt_00047825', 'FBbt_00047429', 'FBbt_00048353', 'FBbt_00111470', 'FBbt_00003875', 'FBbt_00067021', 'FBbt_00100381', 'FBbt_00111355', 'FBbt_00047720', 'FBbt_00067364', 'FBbt_00100388', 'FBbt_00048520', 'FBbt_00003880', 'FBbt_00100489'])
-    #     print("Testing and printing first result in list only.")
-    #     r = self.qw.test(t=self,
-    #                      query=query, single=False)
+        print("Testing and printing first result in list only.")
+        r = self.qw.test(t=self,
+                         query=query, single=False)
+
+    def test_template_2_datasets_query(self):
+        query = self.ql.template_2_datasets_query('VFB_00050000')
+        print("Testing and printing first result in list only.")
+        r = self.qw.test(t=self,
+                         query=query, single=False)
+
+    def test_all_datasets_query(self):
+        query = self.ql.all_datasets_query()
+        print("Testing and printing first result in list only.")
+        r = self.qw.test(t=self,
+                         query=query, single=False)
+
+    def test_anatomy_query(self):
+        query = self.ql.anat_query(short_forms=['FBbt_00048350', 'FBbt_00047826', 'FBbt_00111338', 'FBbt_00048346', 'FBbt_00047227', 'FBbt_00007445', 'FBbt_00003864', 'FBbt_00007452', 'FBbt_00111354', 'FBbt_00007476', 'FBbt_00111661', 'FBbt_00049514', 'FBbt_00100470', 'FBbt_00100225', 'FBbt_00110570', 'FBbt_00111685', 'FBbt_00047723', 'FBbt_00110086', 'FBbt_00067349', 'FBbt_00007444', 'FBbt_00048354', 'FBbt_00003879', 'FBbt_00111481', 'FBbt_00067369', 'FBbt_00111359', 'FBbt_00067350', 'FBbt_00111749', 'FBbt_00100485', 'FBbt_00003994', 'FBbt_00007437', 'FBbt_00110427', 'FBbt_00110983', 'FBbt_00047681', 'FBbt_00067123', 'FBbt_00111715', 'FBbt_00047724', 'FBbt_00047825', 'FBbt_00047429', 'FBbt_00048353', 'FBbt_00111470', 'FBbt_00003875', 'FBbt_00067021', 'FBbt_00100381', 'FBbt_00111355', 'FBbt_00047720', 'FBbt_00067364', 'FBbt_00100388', 'FBbt_00048520', 'FBbt_00003880', 'FBbt_00100489'])
+        print("Testing and printing first result in list only.")
+        r = self.qw.test(t=self,
+                         query=query, single=False)
 
 
 if __name__ == '__main__':

--- a/src/vfb_query_builder/test/test_tools.py
+++ b/src/vfb_query_builder/test/test_tools.py
@@ -9,15 +9,12 @@ import warnings
 class TestWrapper:
 
     def __init__(self, schema):
-
-
-
         # This is all completely dependent on repo structure!
         # Ideally it would be configured by passing path as arg
         # But passing args doesn't work reliably with unittest lib.
-        pwdl = os.getcwd()
-        base = 'file://' + pwdl + '/json_schema/'
-        self.V = get_validator(pwdl + "/json_schema/" + schema,
+        pwdl = os.path.dirname(os.path.abspath(__file__))
+        base = 'file://' + pwdl + '/../../json_schema/'
+        self.V = get_validator(pwdl + "/../../json_schema/" + schema,
                                base_uri=base)
         self.nc = Neo4jConnect('http://pdb.p2.virtualflybrain.org', 'neo4j', 'neo4j')
 


### PR DESCRIPTION
A new query roller that uses python_cypher (pypher) library to generate cypher queries instead of using string operations. 

New roller (pypher_query_roller.py) provides the same interface with the existing roller (query_roller.py). So can be easily switched between the rollers. Now, still the string operations based roller is the active roller. 