### PR TITLE
Hiding relationship edges in term info

### DIFF
--- a/src/vfb_query_builder/query_roller.py
+++ b/src/vfb_query_builder/query_roller.py
@@ -230,7 +230,8 @@ class QueryLibraryCore:
 
     def relationships(self): return (Clause(vars=["relationships"],
                                             MATCH=Template("OPTIONAL MATCH "
-                                                           "(o:Class)<-[r {type:'Related'}]-($pvar$labels)"),
+                                                           "(o:Class)<-[r {type:'Related'}]-($pvar$labels) "
+                                                           "WHERE NOT EXISTS(r.hide_in_terminfo) OR r.hide_in_terminfo <> [TRUE]"),
                                             WITH="CASE WHEN o IS NULL THEN [] "
                                                  "ELSE COLLECT ({ relation: %s, object: %s }) "
                                                  "END AS relationships " % (roll_min_edge_info("r"),

--- a/src/vfb_query_builder/test/TermInfo_schema_tests.py
+++ b/src/vfb_query_builder/test/TermInfo_schema_tests.py
@@ -80,6 +80,20 @@ class TermInfoRollerTest(unittest.TestCase):
         r = self.qw.test(t=self,
                          query=query)
 
+    def test_individual_hidden_relationships(self):
+        query = query_builder(query_labels=["Individual"],
+                              clauses=[self.ql.term(),
+                                       self.ql.relationships()],
+                              query_short_forms=['FBlc0003917'])
+        r = self.qw.test(t=self,
+                         query=query)
+
+        # ensure relationship edges with 'hide_in_terminfo = TRUE' are hidden in term info
+        relationships = r[0]["relationships"]
+        self.assertEqual(2, len(relationships))
+        expresses_relations = [rel for rel in relationships if rel["relation"]["label"] == "expresses"]
+        self.assertEqual(0, len(expresses_relations))
+
     def test_individual_parents(self):
         query = query_builder(query_labels=["Individual"],
                               clauses=[self.ql.term(),


### PR DESCRIPTION
Fix issue #109

Ensures relationship edges with 'hide_in_terminfo = TRUE' are hidden in the term info